### PR TITLE
docs: refine docs and naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-# TODO PACKAGE NAME
 name = "cakedb"
 version = "0.1.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CakeDb
 
-A small wrapper over [redb](https://crates.io/crates/redb) (a simple, portable, high-performance, ACID, embedded key-value store). The API is a piece of cake, so you can work on your business logic and worry less about the database.
+A small wrapper over [redb](https://crates.io/crates/redb) (a simple, portable, high-performance, ACID, embedded key-value store).
+The API is a piece of cake, so you can work on your business logic and worry less about the database.
 
 ## Features
 

--- a/src/generic/internal.rs
+++ b/src/generic/internal.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use redb::{
-    MultimapTableDefinition, ReadOnlyMultimapTable, ReadOnlyTable, ReadableDatabase, TableDefinition, TableError
+    MultimapTableDefinition, ReadOnlyMultimapTable, ReadOnlyTable, ReadableDatabase,
+    TableDefinition, TableError,
 };
 
 use crate::{bincode_wrapper::Bincode, CakeDb};
@@ -50,7 +51,7 @@ impl CakeDb {
     /// Opens the given multimap table as read-only and returns it.
     pub(super) fn read_multimap_table<K, V>(
         &self,
-        table: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
+        table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
     ) -> Result<ReadOnlyMultimapTable<Bincode<K>, Bincode<V>>, Box<dyn std::error::Error>>
     where
         K: DbKey,
@@ -59,8 +60,8 @@ impl CakeDb {
         Ok(self
             .inner
             .begin_read()
-            .map_err(|e| anyhow!("failed to begin read for '{table}': {e}"))?
-            .open_multimap_table(table)
-            .map_err(|e| anyhow!("failed to open table for '{table}': {e}"))?)
+            .map_err(|e| anyhow!("failed to begin read for '{table_def}': {e}"))?
+            .open_multimap_table(table_def)
+            .map_err(|e| anyhow!("failed to open table for '{table_def}': {e}"))?)
     }
 }

--- a/src/generic/multimap_reads.rs
+++ b/src/generic/multimap_reads.rs
@@ -10,7 +10,7 @@ impl CakeDb {
     /// Returns all values mapped to the given key.
     pub fn multimap_get<K, V>(
         &self,
-        table: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
+        table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
         key: &K,
     ) -> Result<BTreeSet<V>, Box<dyn std::error::Error>>
     where
@@ -18,7 +18,7 @@ impl CakeDb {
         V: DbValue + Ord,
     {
         Ok(self
-            .read_multimap_table(table)?
+            .read_multimap_table(table_def)?
             .get(key)?
             .flatten()
             .map(|vg| vg.value())
@@ -28,14 +28,14 @@ impl CakeDb {
     /// Returns all key-value mappings in the given table.
     pub fn multimap_table<K, V>(
         &self,
-        table: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
+        table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
     ) -> Result<BTreeMap<K, BTreeSet<V>>, Box<dyn std::error::Error>>
     where
         K: DbKey,
         V: DbValue + Ord,
     {
         Ok(self
-            .read_multimap_table(table)?
+            .read_multimap_table(table_def)?
             .iter()?
             .flatten()
             .map(|(key_ag, value_ag)| {

--- a/src/generic/writes.rs
+++ b/src/generic/writes.rs
@@ -41,7 +41,7 @@ impl CakeDb {
     /// Inserts a key-value pair into the table.
     ///
     /// If the map had this key present, its value will be overwritten by the new value.
-    /// 
+    ///
     /// Returns the old value.
     pub fn insert<K, V>(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use redb::{Database};
+use redb::Database;
 use save::CakeSavepoint;
 use tempfile::NamedTempFile;
 
 /// Represents a high-level database encapsulation that handles interactions with the underlying storage.
 ///
-/// Usage of the provided methods is encouraged, but if you need to do anything more advanced, you can use the `database` and `mut_database` methods to access the `redb` database directly.
+/// Usage of the provided methods is encouraged, but if you need more control,
+/// the [`database`](Self::database) and [`mut_database`](Self::mut_database)
+/// methods expose the underlying `redb::Database`.
 ///
 /// # Examples
 /// ```
@@ -77,7 +79,9 @@ pub struct CakeDb {
 impl CakeDb {
     /// Initializes the database, or creates it if it doesn't exist.
     ///
-    /// If you are just testing the crate, you can also use the `new_test_db` method, or use your PC's default Data path by calling the provided `data_local_path` function.
+    /// If you're just testing the crate, consider the [`new_test_db`](Self::new_test_db)
+    /// method, or obtain your machine's default data path with
+    /// [`data_local_path`](crate::data_local_path).
     pub fn new(path: impl AsRef<Path>) -> Result<Self, redb::DatabaseError> {
         Ok(Self {
             inner: Database::create(path)?,
@@ -127,12 +131,12 @@ impl CakeDb {
 
 /// Returns the path to your computer's local data directory.
 ///
-/// |Platform | Value                                                                      | Example                                                       |
-/// | ------- | -------------------------------------------------------------------------- | ------------------------------------------------------------- |
-/// | Linux   | `$XDG_DATA_HOME`/`_project_path_` or `$HOME`/.local/share/`_project_path_` | /home/alice/.local/share/ezdb                               |
-/// | macOS   | `$HOME`/Library/Application Support/`_project_path_`                       | /Users/Alice/Library/Application Support/EzDb |
-/// | Windows | `{FOLDERID_LocalAppData}`\\`_project_path_`\\data                          | C:\Users\Alice\AppData\Local\EzDb\data            |
+/// | Platform | Value                                                             | Example                                               |
+/// | ------- | ----------------------------------------------------------------- | ----------------------------------------------------- |
+/// | Linux   | `$XDG_DATA_HOME`/`cakedb` or `$HOME`/.local/share/`cakedb`         | `/home/alice/.local/share/cakedb`                     |
+/// | macOS   | `$HOME`/Library/Application Support/`cakedb`                       | `/Users/Alice/Library/Application Support/cakedb`     |
+/// | Windows | `{FOLDERID_LocalAppData}`\`cakedb`\data                          | `C:\Users\Alice\AppData\Local\cakedb\data` |
 pub fn data_local_path() -> Option<PathBuf> {
-    directories::ProjectDirs::from("", "", "EzDb")
+    directories::ProjectDirs::from("", "", "cakedb")
         .map(|db_dir| db_dir.data_local_dir().to_path_buf())
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use serde_derive::{Serialize, Deserialize};
+pub use crate::{bincode_wrapper::Bincode, CakeDb};
 pub use bincode::{Decode, Encode};
 pub use redb::TableDefinition;
-pub use crate::{CakeDb, bincode_wrapper::Bincode};
+pub use serde_derive::{Deserialize, Serialize};

--- a/src/save.rs
+++ b/src/save.rs
@@ -5,15 +5,19 @@ use time::UtcDateTime;
 
 use crate::CakeDb;
 
+/// Metadata for a savepoint stored in memory.
 pub struct CakeSavepoint {
+    /// The underlying `redb` savepoint.
     pub savepoint: Savepoint,
+    /// When the savepoint was created.
     pub creation_time: UtcDateTime,
 }
 
 impl CakeDb {
-    /// Creates a new savepoint and returns its key. The savepoint is stored in-memory inside the struct itself, not in the database.
+    /// Creates a new savepoint and returns its key.
     ///
-    /// These savepoints are ephemeral; they will become invalid if the `CakeDb` reference is dropped.
+    /// The savepoint is stored in memory inside the struct itself, not in the database.
+    /// These savepoints are ephemeral and become invalid if the [`CakeDb`] instance is dropped.
     pub fn savepoint(&mut self) -> Result<usize, Box<dyn std::error::Error>> {
         let write = self.inner.begin_write()?;
         let savepoint = write.ephemeral_savepoint()?;


### PR DESCRIPTION
## Summary
- clarify how to access the underlying `redb::Database`
- document default data path using `cakedb`
- improve savepoint docs and multimap naming

## Testing
- `cargo fmt`
- `cargo test` *(fails: rustc 1.88.0 is not supported by redb 3.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689facfa47a88332bee233d4a2a104ff