### PR TITLE
Add crate docs and derive Debug for public types

### DIFF
--- a/src/bincode_wrapper.rs
+++ b/src/bincode_wrapper.rs
@@ -1,3 +1,5 @@
+//! Bincode-backed wrapper types for use with `redb`.
+
 use std::any::type_name;
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -35,6 +37,7 @@ where
         Self: 'a,
     {
         bincode::decode_from_slice(data, config::standard())
+            // TODO: replace `expect` with proper error handling.
             .expect("failed to deserialize bincode value")
             .0
     }
@@ -44,6 +47,7 @@ where
         Self: 'a + 'b,
     {
         bincode::encode_to_vec(value, config::standard())
+            // TODO: replace `expect` with proper error handling.
             .expect("failed to serialize bincode value")
     }
 

--- a/src/generic/batch_writes.rs
+++ b/src/generic/batch_writes.rs
@@ -1,8 +1,12 @@
+//! Batch write helpers for working with multiple entries at once.
+
 use redb::{ReadableTable, TableDefinition};
 
 use crate::{bincode_wrapper::Bincode, CakeDb};
 
 use super::traits::{DbKey, DbValue};
+
+// TODO: replace `Box<dyn std::error::Error>` with a structured error type.
 
 impl CakeDb {
     /// Inserts all key-value pairs into the given table.
@@ -87,6 +91,7 @@ impl CakeDb {
     /// Deletes the given table.
     ///
     /// Returns `true` if the table existed.
+    #[must_use]
     pub fn delete_table<K, V>(
         &self,
         table_def: TableDefinition<Bincode<K>, Bincode<V>>,

--- a/src/generic/mod.rs
+++ b/src/generic/mod.rs
@@ -1,3 +1,5 @@
+//! Generic database helpers shared across the crate.
+
 pub mod batch_writes;
 pub mod internal;
 pub mod multimap_reads;

--- a/src/generic/multimap_reads.rs
+++ b/src/generic/multimap_reads.rs
@@ -1,3 +1,5 @@
+//! Read operations for multimap tables.
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use redb::{MultimapTableDefinition, ReadableMultimapTable};
@@ -5,6 +7,8 @@ use redb::{MultimapTableDefinition, ReadableMultimapTable};
 use crate::{bincode_wrapper::Bincode, CakeDb};
 
 use super::traits::{DbKey, DbValue};
+
+// TODO: replace `Box<dyn std::error::Error>` with a structured error type.
 
 impl CakeDb {
     /// Returns all values mapped to the given key.

--- a/src/generic/multimap_writes.rs
+++ b/src/generic/multimap_writes.rs
@@ -1,13 +1,18 @@
+//! Write operations for multimap tables.
+
 use redb::{MultimapTableDefinition, ReadableMultimapTable};
 
 use crate::{bincode_wrapper::Bincode, CakeDb};
 
 use super::traits::{DbKey, DbValue};
 
+// TODO: replace `Box<dyn std::error::Error>` with a structured error type.
+
 impl CakeDb {
     /// Adds a given value to the mapping of the key.
     ///
     /// Returns `true` if the key-value pair was present.
+    #[must_use]
     pub fn multimap_insert<K, V>(
         &mut self,
         table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
@@ -33,6 +38,7 @@ impl CakeDb {
     /// Adds the given values to the mapping of the key.
     ///
     /// Returns `true` if the key already had at least one value mapped.
+    #[must_use]
     pub fn multimap_insert_values<K, V>(
         &mut self,
         table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
@@ -92,6 +98,7 @@ impl CakeDb {
     /// Regardless of overlap with new values, all old values will be removed.
     ///
     /// Returns `true` if the key had at least one value mapped.
+    #[must_use]
     pub fn multimap_assign<K, V>(
         &mut self,
         table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
@@ -124,6 +131,7 @@ impl CakeDb {
     /// Removes a given value from the mapping of the key.
     ///
     /// Returns `true` if the value was present.
+    #[must_use]
     pub fn multimap_remove<K, V>(
         &mut self,
         table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,
@@ -200,6 +208,7 @@ impl CakeDb {
     /// Deletes the given multimap table.
     ///
     /// Returns `true` if the table existed.
+    #[must_use]
     pub fn delete_multimap_table<K, V>(
         &mut self,
         table_def: MultimapTableDefinition<Bincode<K>, Bincode<V>>,

--- a/src/generic/reads.rs
+++ b/src/generic/reads.rs
@@ -1,3 +1,5 @@
+//! Read operations on key-value tables.
+
 use std::{collections::BTreeMap, ops::RangeBounds};
 
 use redb::{ReadableTable, TableDefinition};
@@ -5,6 +7,8 @@ use redb::{ReadableTable, TableDefinition};
 use crate::{bincode_wrapper::Bincode, CakeDb};
 
 use super::traits::{DbKey, DbValue};
+
+// TODO: replace `Box<dyn std::error::Error>` with a structured error type.
 
 impl CakeDb {
     /// Returns the value if it exists.
@@ -21,6 +25,7 @@ impl CakeDb {
     }
 
     /// Returns `true` if the table contains the given key.
+    #[must_use]
     pub fn contains_key<K, V>(
         &self,
         table_def: TableDefinition<Bincode<K>, Bincode<V>>,

--- a/src/generic/traits.rs
+++ b/src/generic/traits.rs
@@ -2,11 +2,37 @@ use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
+/// Types that can act as keys in CakeDb tables.
+///
+/// Any type implementing the required traits automatically implements `DbKey`.
+///
+/// # Examples
+/// ```
+/// use cakedb::prelude::*;
+///
+/// #[derive(Serialize, Deserialize, Encode, Decode, Debug, Ord, PartialOrd, Eq, PartialEq)]
+/// struct MyKey(u32);
+///
+/// fn assert_db_key<K: DbKey>() {}
+/// assert_db_key::<MyKey>();
+/// ```
 pub trait DbKey: Serialize + for<'de> Deserialize<'de> + Decode<()> + Encode + Debug + Ord {}
 impl<T> DbKey for T where
     T: Serialize + for<'de> Deserialize<'de> + Decode<()> + Encode + Debug + Ord
 {
 }
 
+/// Types that can be stored as values in CakeDb tables.
+///
+/// # Examples
+/// ```
+/// use cakedb::prelude::*;
+///
+/// #[derive(Serialize, Deserialize, Encode, Decode, Debug)]
+/// struct MyValue(String);
+///
+/// fn assert_db_value<V: DbValue>() {}
+/// assert_db_value::<MyValue>();
+/// ```
 pub trait DbValue: Serialize + for<'de> Deserialize<'de> + Decode<()> + Encode + Debug {}
 impl<T> DbValue for T where T: Serialize + for<'de> Deserialize<'de> + Decode<()> + Encode + Debug {}

--- a/src/generic/writes.rs
+++ b/src/generic/writes.rs
@@ -1,8 +1,12 @@
+//! Basic write operations on key-value tables.
+
 use redb::{ReadableTable, TableDefinition};
 
 use crate::{bincode_wrapper::Bincode, CakeDb};
 
 use super::traits::{DbKey, DbValue};
+
+// TODO: replace `Box<dyn std::error::Error>` with a structured error type.
 
 impl CakeDb {
     /// Tries to add a key-value pair to the table.
@@ -10,6 +14,7 @@ impl CakeDb {
     /// Returns whether the key was newly added. That is:
     /// - If this key **wasn't** present, adds the key-value pair and returns `true`.
     /// - If this key **was** present, returns `false` and does not modify the table.
+    #[must_use]
     pub fn try_add<K, V>(
         &mut self,
         table_def: TableDefinition<Bincode<K>, Bincode<V>>,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,6 @@
-pub use crate::{bincode_wrapper::Bincode, CakeDb};
+//! Convenience re-exports for building applications with CakeDb.
+
+pub use crate::{bincode_wrapper::Bincode, CakeDb, DbKey, DbValue};
 pub use bincode::{Decode, Encode};
 pub use redb::TableDefinition;
 pub use serde_derive::{Deserialize, Serialize};

--- a/src/save.rs
+++ b/src/save.rs
@@ -1,3 +1,5 @@
+//! Utilities for managing in-memory savepoints.
+
 use std::collections::BTreeMap;
 
 use redb::Savepoint;
@@ -5,12 +7,27 @@ use time::UtcDateTime;
 
 use crate::CakeDb;
 
+// TODO: replace `Box<dyn std::error::Error>` with a structured error type.
+
 /// Metadata for a savepoint stored in memory.
+#[derive(Debug)]
 pub struct CakeSavepoint {
     /// The underlying `redb` savepoint.
-    pub savepoint: Savepoint,
+    savepoint: Savepoint,
     /// When the savepoint was created.
-    pub creation_time: UtcDateTime,
+    creation_time: UtcDateTime,
+}
+
+impl CakeSavepoint {
+    /// Returns a reference to the underlying `redb` savepoint.
+    pub const fn savepoint(&self) -> &Savepoint {
+        &self.savepoint
+    }
+
+    /// Returns when the savepoint was created.
+    pub const fn creation_time(&self) -> UtcDateTime {
+        self.creation_time
+    }
 }
 
 impl CakeDb {


### PR DESCRIPTION
## Summary
- document crate and modules, restrict internal module visibility
- derive `Debug` for `CakeDb` and `CakeSavepoint`
- hide savepoint internals and add accessors
- add TODOs for future error handling improvements and add `#[must_use]` to significant boolean methods

## Testing
- `cargo test` *(fails: rustc 1.88.0 is not supported by redb@3.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bbe800d88332b0734e529688f137